### PR TITLE
Need binder instance to build from kaust-vislab fork

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 [![Create a Slack Account with us](https://img.shields.io/badge/Create_Slack_Account-The_Carpentries-071159.svg)](https://swc-slack-invite.herokuapp.com/) 
 [![Slack Status](https://img.shields.io/badge/Slack_Channel-swc--py--gapminder-E01563.svg)](https://swcarpentry.slack.com/messages/C9X4W03KL) 
-[![Binder](https://mybinder.org/badge_logo.svg)](https://mybinder.org/v2/gh/swcarpentry/python-novice-gapminder/binder?urlpath=lab)
+[![Binder](https://mybinder.org/badge_logo.svg)](https://mybinder.org/v2/gh/kaust-vislab/python-novice-gapminder/binder?urlpath=lab)
 
 python-novice-gapminder
 =======================


### PR DESCRIPTION
This PR changes the link in the README so that the binder instance builds from the `kaust-vislab` fork.